### PR TITLE
Send feedback to Plausible

### DIFF
--- a/src/components/FeedbackForm/index.jsx
+++ b/src/components/FeedbackForm/index.jsx
@@ -68,12 +68,12 @@ export const FeedbackForm = ({
                     onVote(id);
                 }
 
-                const selectedOption = options?.ordered?.find(option => option.id === id);
-                if (selectedOption && typeof plausible === 'function') {
+                if (typeof plausible === 'function') {
                     plausible('Feedback', {
                         props: {
                             code: code.code,
-                            feedback: selectedOption.type
+                            feedback_option_id: id,
+                            resource_id: resourceId,
                         }
                     });
                 }

--- a/src/components/FeedbackForm/index.jsx
+++ b/src/components/FeedbackForm/index.jsx
@@ -67,6 +67,16 @@ export const FeedbackForm = ({
                 if (isFunction(onVote)) {
                     onVote(id);
                 }
+
+                const selectedOption = options?.ordered?.find(option => option.id === id);
+                if (selectedOption && typeof plausible === 'function') {
+                    plausible('Feedback', {
+                        props: {
+                            code: code.code,
+                            feedback: selectedOption.type
+                        }
+                    });
+                }
             }
         );
     };


### PR DESCRIPTION
I think  we could get some really cool insights if we send the feedback to Plausible. For example we could compare how many people go vegan after watching the 3mmc in France vs Germany. 

It would be nice if we can get the (English) label here for the feedback option and resource instead of the ids. Not sure on how to do that though.

We can also use a css class approach here, but I think that can get messy: https://plausible.io/docs/custom-event-goals#step-3-add-a-css-class-name-to-the-element-you-want-to-track-on-your-site